### PR TITLE
Removing #ifdef constructions

### DIFF
--- a/src/lzo1x_decompress_safe.c
+++ b/src/lzo1x_decompress_safe.c
@@ -117,22 +117,6 @@ int lzo1x_decompress_safe(const unsigned char *in, size_t in_len,
 				}
 				t += 3;
 copy_literal_run:
-#if defined(CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS)
-				if (likely(HAVE_IP(t + 15) && HAVE_OP(t + 15))) {
-					const unsigned char *ie = ip + t;
-					unsigned char *oe = op + t;
-					do {
-						COPY8(op, ip);
-						op += 8;
-						ip += 8;
-						COPY8(op, ip);
-						op += 8;
-						ip += 8;
-					} while (ip < ie);
-					ip = ie;
-					op = oe;
-				} else
-#endif
 				{
 					NEED_OP(t);
 					NEED_IP(t + 3);
@@ -235,34 +219,6 @@ copy_literal_run:
 			}
 		}
 		TEST_LB(m_pos);
-#if defined(CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS)
-		if (op - m_pos >= 8) {
-			unsigned char *oe = op + t;
-			if (likely(HAVE_OP(t + 15))) {
-				do {
-					COPY8(op, m_pos);
-					op += 8;
-					m_pos += 8;
-					COPY8(op, m_pos);
-					op += 8;
-					m_pos += 8;
-				} while (op < oe);
-				op = oe;
-				if (HAVE_IP(6)) {
-					state = next;
-					COPY4(op, ip);
-					op += next;
-					ip += next;
-					continue;
-				}
-			} else {
-				NEED_OP(t);
-				do {
-					*op++ = *m_pos++;
-				} while (op < oe);
-			}
-		} else
-#endif
 		{
 			unsigned char *oe = op + t;
 			NEED_OP(t);
@@ -277,13 +233,6 @@ copy_literal_run:
 match_next:
 		state = next;
 		t = next;
-#if defined(CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS)
-		if (likely(HAVE_IP(6) && HAVE_OP(4))) {
-			COPY4(op, ip);
-			op += t;
-			ip += t;
-		} else
-#endif
 		{
 			NEED_IP(t + 3);
 			NEED_OP(t);


### PR DESCRIPTION
Delete unused code because defines in ifdef will don't be defined anyway. For make code weight less, this ifdefs has been deleted 